### PR TITLE
Take SSL credentials from default environment variables

### DIFF
--- a/IBCQC_NetCore/Program.cs
+++ b/IBCQC_NetCore/Program.cs
@@ -40,7 +40,6 @@ namespace IBCQC_NetCore
 
                            //use to set to port 443 and apply a certificate
                          //   o.ListenAnyIP(32770, ListenOptions => { ListenOptions.UseHttps("testing.ironbridgeapi.com.pfx", "$London123"); });      
-                         o.ListenAnyIP(443, ListenOptions => { ListenOptions.UseHttps("dev.ironbridgeapi.com.pfx", "$London123"); });
 
                        });
                    });


### PR DESCRIPTION
Without this line, the SSL credentials are taken from `ASPNETCORE_Kestrel__Certificates__Default__Path` and `ASPNETCORE_Kestrel__Certificates__Default__Password`